### PR TITLE
Update pidlock.rb

### DIFF
--- a/lib/pidlock.rb
+++ b/lib/pidlock.rb
@@ -19,7 +19,7 @@ class Pidlock
   def lock
     unless @file
       unless (File.writable?(File.dirname(@filename)))
-        @filename = File.join('/', 'tmp', @name)
+        @filename = File.join('/', 'tmp', @filename)
       end
       @file = File.open(@filename, 'r+') 
       if (old_pid = @file.gets)


### PR DESCRIPTION
if you specify @name = "test/ruby.pid" it tries to write to /tmp/test/ruby.pid where the folder test does not exist.
